### PR TITLE
[Feat/execute] init, util함수 구현

### DIFF
--- a/libs/libft/Makefile
+++ b/libs/libft/Makefile
@@ -31,6 +31,7 @@ SRCS		= ft_isalpha.c \
 			ft_tolower.c \
 			ft_strchr.c \
 			ft_strrchr.c \
+			ft_strcmp.c \
 			ft_strncmp.c \
 			ft_memchr.c \
 			ft_memcmp.c \

--- a/libs/libft/ft_strcmp.c
+++ b/libs/libft/ft_strcmp.c
@@ -1,6 +1,6 @@
 #include "libft.h"
 
-int	ft_strcmp(const *str1, const *str2)
+int	ft_strcmp(const char *str1, const char *str2)
 {
 	while (*str1 || *str2)
 	{

--- a/libs/libft/libft.h
+++ b/libs/libft/libft.h
@@ -39,7 +39,7 @@ int		ft_toupper(int c);
 int		ft_tolower(int c);
 char	*ft_strchr(const char *s, int c);
 char	*ft_strrchr(const char *s, int c);
-int		ft_strcmp(const *str1, const *str2);
+int		ft_strcmp(const char *str1, const char *str2);
 int		ft_strncmp(const char *s1, const char *s2, size_t n);
 void	*ft_memchr(const void *s, int c, size_t n);
 int		ft_memcmp(const void *s1, const void *s2, size_t n);

--- a/libs/libft/libft.h
+++ b/libs/libft/libft.h
@@ -39,6 +39,7 @@ int		ft_toupper(int c);
 int		ft_tolower(int c);
 char	*ft_strchr(const char *s, int c);
 char	*ft_strrchr(const char *s, int c);
+int		ft_strcmp(const *str1, const *str2);
 int		ft_strncmp(const char *s1, const char *s2, size_t n);
 void	*ft_memchr(const void *s, int c, size_t n);
 int		ft_memcmp(const void *s1, const void *s2, size_t n);

--- a/srcs/execute/builtin.c
+++ b/srcs/execute/builtin.c
@@ -6,9 +6,9 @@ void	single_builtin(t_argv *argv, t_env **env)
 	int	origin_stdin;
 	int	origin_stdout;
 
-	origin_stdin = ft_dup(STDIN_FILENO);
-	origin_stdout = ft_dup(STDOUT_FILENO);
-	if (set_stdin(argv) || set_stdout(argv))
+	origin_stdin = dup(STDIN_FILENO);
+	origin_stdout = dup(STDOUT_FILENO);
+	if (set_stdin_redir(argv) || set_stdout_redir(argv))
 	{
 		single_builtin_error();//에러 처리
 		return ;

--- a/srcs/execute/builtin.c
+++ b/srcs/execute/builtin.c
@@ -1,7 +1,6 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 
-void	single_builtin(t_argv *argv, t_env **env)
+void	single_builtin(t_argv *argv, t_env *env)
 {
 	int	origin_stdin;
 	int	origin_stdout;

--- a/srcs/execute/child.c
+++ b/srcs/execute/child.c
@@ -1,7 +1,6 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 
-void	child_process(t_argv *argv, t_pipe pipe, int i, t_env **env)
+void	child_process(t_argv *argv, t_pipe pipe, int i, t_env *env)
 {
 	set_stdin_pipe(pipe, i - 1);
 	set_stdout_pipe(argv, pipe, i);

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -32,7 +32,7 @@ void	end_execute(int cnt_pipe, pid_t **pids, t_pipe pipes, t_argv *argv)
 {
 	wait_childs(cnt_pipe); // -> exit status 변경해줘야함 "$?"
 	close_pipe(pipes, cnt_pipe);
-	free_pids(pids);
+	free(pids);
 	free_pipe(pipes.pipe, cnt_pipe);
 	free_argv(argv);
 }

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -1,11 +1,13 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 
 void	init_execute(int *cnt_pipe, pid_t **pids, t_pipe *pipes, t_argv *argv)
 {
 	set_pipe_num(&cnt_pipe, argv);
-	set_pids(&pids, cnt_pipe);
-	set_pipe(pipes, cnt_pipe);
+	if (*cnt_pipe > 0)
+	{
+		set_pids(&pids, cnt_pipe);
+		set_pipe(pipes, cnt_pipe);
+	}
 }
 
 void	wait_childs(int cnt_pipe)
@@ -35,7 +37,7 @@ void	end_execute(int cnt_pipe, pid_t **pids, t_pipe pipes, t_argv *argv)
 	free_argv(argv);
 }
 
-void	execute(t_argv *argv, t_env **env)
+void	execute(t_argv *argv, t_env *env)
 {
 	int		i;
 	int		cnt_pipe;
@@ -62,5 +64,5 @@ void	execute(t_argv *argv, t_env **env)
 			argv = argv->next;
 		}
 	}
-	end_execute(cnt_pipe, &pids, pipes, argv);
+	end_execute(cnt_pipe, pids, pipes, argv);
 }

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -1,19 +1,37 @@
 #include "../../includes/minishell.h"
 #include "../../includes/execute.h"
 
-int		init_execute(int *cnt_pipe, pid_t **pids, t_pipe *pipes, t_argv *argv)
+void	init_execute(int *cnt_pipe, pid_t **pids, t_pipe *pipes, t_argv *argv)
 {
-	// set_pipe_num(&cnt_pipe);
-	// set_pids(&pids, cnt_pipe);
-	// set_pipe(&pipe, cnt_pipe);
+	set_pipe_num(&cnt_pipe, argv);
+	set_pids(&pids, cnt_pipe);
+	set_pipe(pipes, cnt_pipe);
+}
+
+void	wait_childs(int cnt_pipe)
+{
+	int	i;
+	int	status;
+
+	i = -1;
+	status = 0;
+	while (++i < cnt_pipe)
+	{
+		if (wait(&status) < 0)
+			status = 1;
+	}
+	if (status > 1)
+		status = status >> 8;
+	g_error.errno = status;
+	g_error.last_errno = status;
 }
 
 void	end_execute(int cnt_pipe, pid_t **pids, t_pipe pipes, t_argv *argv)
 {
-	wait_childs(pids, cnt_pipe); // -> exit status 변경해줘야함 "$?"
+	wait_childs(cnt_pipe); // -> exit status 변경해줘야함 "$?"
 	close_pipe(pipes, cnt_pipe);
-	free_pids(pids, cnt_pipe);
-	free_pipe(pipes, cnt_pipe);
+	free_pids(pids);
+	free_pipe(pipes.pipe, cnt_pipe);
 	free_argv(argv);
 }
 
@@ -25,11 +43,10 @@ void	execute(t_argv *argv, t_env **env)
 	pid_t	*pids;
 
 	if (make_heredoc(argv) == FAIL)
-		return ;	// FAIL일 경우 할당 해제 필요
-	if (init_execute(&cnt_pipe, &pids, &pipes, argv) == FAIL)
-		return ;  // FAIL일 경우 할당 해제 필요
+		return (free_argv(argv));	// FAIL일 경우 할당 해제 필요
+	init_execute(&cnt_pipe, &pids, &pipes, argv);
 	i = -1;
-	if (cnt_pipe == 0 && is_builtin(argv->cmd[0]))
+	if (cnt_pipe == 0 && is_builtin(argv->cmd[0]) == SUCCESS)
 		single_builtin(argv, env);
 	else
 	{
@@ -40,6 +57,8 @@ void	execute(t_argv *argv, t_env **env)
 			{
 				child_process(argv, pipes, i, env);
 			}
+			if (pids[i] < 0)
+				perror("ERROR");
 			argv = argv->next;
 		}
 	}

--- a/srcs/execute/frees.c
+++ b/srcs/execute/frees.c
@@ -1,12 +1,8 @@
 #include "../../includes/minishell.h"
 
-void	free_pids(pid_t *pids, int cnt)
+void	free_pids(pid_t **pids, int cnt)
 {
-	int	i;
-
-	i = -1;
-	while (++i < cnt)
-		free(pids);
+	free(*pids);
 }
 
 void	free_pipes(int **pipes, int cnt)
@@ -17,6 +13,30 @@ void	free_pipes(int **pipes, int cnt)
 	while (++i < cnt)
 		free(pipes[i]);
 	free(pipes);
+}
+
+void	free_redir(t_type *type)
+{
+	t_type	*tmp;
+
+	while (type)
+	{
+		tmp = type->next;
+		free(type);
+		type = tmp;
+	}
+}
+
+void	free_strs(char **strs)
+{
+	int	i;
+
+	i = -1;
+	while (strs[++i])
+	{
+		free(strs[i]);
+	}
+	free(strs);
 }
 
 void	free_argv(t_argv *argv)

--- a/srcs/execute/frees.c
+++ b/srcs/execute/frees.c
@@ -1,10 +1,5 @@
 #include "../../includes/minishell.h"
 
-void	free_pids(pid_t *pids, int cnt)
-{
-	free(pids);
-}
-
 void	free_pipes(int **pipes, int cnt)
 {
 	int	i;

--- a/srcs/execute/frees.c
+++ b/srcs/execute/frees.c
@@ -1,8 +1,8 @@
 #include "../../includes/minishell.h"
 
-void	free_pids(pid_t **pids, int cnt)
+void	free_pids(pid_t *pids, int cnt)
 {
-	free(*pids);
+	free(pids);
 }
 
 void	free_pipes(int **pipes, int cnt)

--- a/srcs/execute/ft_strcmp.c
+++ b/srcs/execute/ft_strcmp.c
@@ -1,0 +1,13 @@
+#include "libft.h"
+
+int	ft_strcmp(const *str1, const *str2)
+{
+	while (*str1 || *str2)
+	{
+		if (*str1 != *str2)
+			return (*str1 - *str2);
+		str1++;
+		str2++;
+	}
+	return (*str1 - *str2);
+}

--- a/srcs/execute/heredoc.c
+++ b/srcs/execute/heredoc.c
@@ -19,7 +19,7 @@ static int	run_heredoc(t_type *heredoc)
 				close(fd);
 				break ;
 			}
-			ft_putstr(line, fd);
+			ft_putstr_fd(line, fd);
 			free(line);
 		}
 		close(fd);

--- a/srcs/execute/heredoc.c
+++ b/srcs/execute/heredoc.c
@@ -1,5 +1,4 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 
 static int	run_heredoc(t_type *heredoc)
 {

--- a/srcs/execute/heredoc.c
+++ b/srcs/execute/heredoc.c
@@ -1,16 +1,16 @@
 #include "../../includes/minishell.h"
 #include "../../includes/execute.h"
 
-static int	run_heredoc(t_redir *heredoc)
+static int	run_heredoc(t_type *heredoc)
 {
 	int		fd;
 	char	*line;
-	t_redir	*tmp;
+	t_type	*tmp;
 
 	tmp = heredoc;
 	while (tmp)
 	{
-		fd = ft_open(tmp->value, HEREDOC);
+		fd = ft_open(tmp->value, HDOC);
 		while (1 && fd > 0)
 		{
 			line = readline("> ");
@@ -20,9 +20,10 @@ static int	run_heredoc(t_redir *heredoc)
 				close(fd);
 				break ;
 			}
-			ft_putstr(fd, line);
+			ft_putstr(line, fd);
 			free(line);
 		}
+		close(fd);
 		tmp = tmp->next;
 	}
 	exit (SUCCESS);
@@ -37,8 +38,10 @@ int		make_heredoc(t_argv *argv)
 	if (pid == 0)
 	{
 		// set_heredoc_signal();
-		run_heredoc(argv->heredoc);
+		run_heredoc(argv->hdoc);
 	}
+	if (pid < 0)
+		return (FAIL);
 	wait(&status);
-	return (status << 8);
+	return (status >> 8);
 }

--- a/srcs/execute/init_execute.c
+++ b/srcs/execute/init_execute.c
@@ -1,5 +1,4 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 
 void	set_pipe_cnt(int *cnt_pipe, t_argv *argv)
 {

--- a/srcs/execute/init_execute.c
+++ b/srcs/execute/init_execute.c
@@ -1,0 +1,52 @@
+#include "../../includes/minishell.h"
+#include "../../includes/execute.h"
+
+void	set_pipe_cnt(int *cnt_pipe, t_argv *argv)
+{
+	int	i;
+
+	i = 0;
+	argv = argv->next;
+	while (argv)
+	{
+		argv = argv->next;
+		i++;
+	}
+	*cnt_pipe = i;
+}
+
+void	set_pids(int **pids, int cnt_pipe)
+{
+	*pids = malloc(sizeof(int *) * (cnt_pipe + 1));
+	if (!*pids)
+	{
+		perror("ERROR");
+		exit(FAIL);
+	}
+}
+
+void	set_pipes(t_pipe *pipes, int cnt_pipe)
+{
+	int	i;
+
+	pipes->cnt = cnt_pipe + 1;
+	pipes->pipe = malloc(sizeof(int *) * cnt_pipe);
+	if (!pipes->pipe)
+	{
+		perror("ERROR");
+		exit (FAIL);
+	}
+	i = -1;
+	while (++i < cnt_pipe)
+	{
+		pipes->pipe[i] = malloc(sizeof(int) * 2);
+		if (!pipes->pipe)
+		{
+			perror("ERROR");
+			exit (FAIL);
+		}
+	}
+	i = -1;
+	while (++i < cnt_pipe)
+		pipe(pipes->pipe[i]);
+}

--- a/srcs/execute/pipe.c
+++ b/srcs/execute/pipe.c
@@ -25,7 +25,7 @@ void	set_stdin_pipe(t_pipe pipe, int num)
 		if (i != num)
 			close(pipe.pipe[i][0]);
 	}
-	ft_dup2(pipe.pipe[num][0], STDIN_FILENO);
+	dup2(pipe.pipe[num][0], STDIN_FILENO);
 }
 
 void	set_stdout_pipe(t_argv *argv, t_pipe pipe, int num)
@@ -40,5 +40,5 @@ void	set_stdout_pipe(t_argv *argv, t_pipe pipe, int num)
 		if (i != num)
 			close(pipe.pipe[i][1]);
 	}
-	ft_dup2(pipe.pipe[num][1], STDOUT_FILENO);
+	dup2(pipe.pipe[num][1], STDOUT_FILENO);
 }

--- a/srcs/execute/pipe.c
+++ b/srcs/execute/pipe.c
@@ -1,5 +1,4 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 
 void	close_pipe(t_pipe pipe, int cnt)
 {

--- a/srcs/execute/redir.c
+++ b/srcs/execute/redir.c
@@ -1,5 +1,4 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 
 int	set_stdin_redir(t_argv *argv)
 {

--- a/srcs/execute/redir.c
+++ b/srcs/execute/redir.c
@@ -5,51 +5,48 @@ int	set_stdin_redir(t_argv *argv)
 {
 	int		fd;
 	int		flag;
-	t_redir	*tmp;
+	t_type	*tmp;
 
 	flag = 0;
 	tmp = argv->in;
 	while (tmp)
 	{
-		if (tmp->r_type == INPUT)
-			fd = ft_open(tmp->value, INPUT);
-		if (tmp->r_type == HEREDOC)
-			fd = ft_open(tmp->value, HEREDOC);
+		fd = ft_open(tmp->value, IN);
 		tmp = tmp->next;
 		if (tmp)
 			close(fd);
 	}
-	ft_dup2(fd, STDIN_FILENO);
+	dup2(fd, STDIN_FILENO);
 	return (g_error.errno);
 }
 
 void	reset_stdin(int fd)
 {
-	ft_dup2(fd, STDIN_FILENO);
+	dup2(fd, STDIN_FILENO);
 }
 
 
-int	set_stdout_redir(t_argv *argv)
+int	set_stdout_type(t_argv *argv)
 {
 	int		fd;
-	t_redir	*tmp;
+	t_type	*tmp;
 
 	tmp = argv->out;
 	while (tmp)
 	{
-		if (tmp->r_type == T_OUT)
+		if (tmp->type == T_OUT)
 			fd = ft_open(tmp->value, T_OUT);// 옵션 수정 필요, 실험 요망
-		if (tmp->r_type == A_OUT)
+		if (tmp->type == A_OUT)
 			fd = ft_open(tmp->value, A_OUT);
 		tmp = tmp->next;
 		if (tmp)
 			close(fd);
 	}
-	ft_dup2(fd, STDOUT_FILENO);
+	dup2(fd, STDOUT_FILENO);
 	return (g_error.errno);
 }
 
 void	reset_stdout(int fd)
 {
-	ft_dup2(fd, STDOUT_FILENO);
+	dup2(fd, STDOUT_FILENO);
 }

--- a/srcs/execute/util_execute.c
+++ b/srcs/execute/util_execute.c
@@ -1,5 +1,4 @@
 #include "../../includes/minishell.h"
-#include "../../includes/execute.h"
 #include <fcntl.h>
 
 int	ft_open(char *file, int type)
@@ -25,7 +24,7 @@ int	ft_open(char *file, int type)
 int	is_builtin(char *cmd)
 {
 	int			i;
-	const char	builtins[7][7] = {"echo", "cd", "pwd", "export",
+	const char	*builtins[7] = {"echo", "cd", "pwd", "export",
 		"unset", "env", "exit"};
 
 	i = -1;

--- a/srcs/execute/util_execute.c
+++ b/srcs/execute/util_execute.c
@@ -1,0 +1,38 @@
+#include "../../includes/minishell.h"
+#include "../../includes/execute.h"
+#include <fcntl.h>
+
+int	ft_open(char *file, int type)
+{
+	int	fd;
+
+	if (type == T_OUT)
+		fd = open(file, O_CREAT|O_WRONLY, 0644);
+	if (type == A_OUT)
+		fd = open(file, O_CREAT|O_APPEND|O_WRONLY, 0644);
+	if (type == IN)
+		fd = open(file, O_RDONLY);
+	if (type == HDOC)
+		fd = open(file, O_CREAT|O_WRONLY, S_IRUSR);
+	if (fd < 0)
+	{
+		perror(file);
+		exit(FAIL);
+	}
+	return (fd);
+}
+
+int	is_builtin(char *cmd)
+{
+	int			i;
+	const char	builtins[7][7] = {"echo", "cd", "pwd", "export",
+		"unset", "env", "exit"};
+
+	i = -1;
+	while (++i < 7)
+	{
+		if (ft_strcmp(cmd, builtins[i]) == 0)
+			return (SUCCESS);
+	}
+	return (FAIL);
+}


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - init, util함수 구현
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- 수정 사항
  - 구조체 변경에 따른 수정사항 반영(t_redir -> t_type)
  - free 함수 이상한것들 수정

- util 관련
  - ft_open 구현
  - ft_dup, ft_dup2는 구현 안하고 처리
      - dup함수는 fd가 잘못되거나 너무 많이 open했을 경우에만 에러 처리되는데 fd 잘못되는 경우는 다 open에서 처리되기 때문에 처리하지 않음.
  - is_builtin 구현
  - free 함수 구현 안했던거 구현
  - ft_strcmp 구현

 - init 관련
   - init 실패시 처리 -> init에서는 실패하는 경우가 malloc밖에 없기 때문에 바로 exit시켜줌
   - heredoc 실패시 처리 -> 히어독 만드는 fork 실패시 에러 메시지 출력하고 return, 히어독 파일 만드는거 실패시 에러 + exit(1)로 처리
   - fork 실패시 처리 -> 에러 메시지만 출력하고 end_execute에서 처리하도록 하면 된다는걸 깨달음..!

