### PR TITLE
[Feat] 명령어 경로 찾는 함수 구현 #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.history

--- a/includes/execute.h
+++ b/includes/execute.h
@@ -18,7 +18,8 @@ void	child_process(t_argv *argv, t_env *env, int **pipe, int i);
 /* signal */
 void	set_heredoc_signal(void);
 void	set_child_signal(void);
-
+/* path */
+char	*get_path(t_argv *argv, t_env *env);
 /* util */
 void	*ft_malloc(size_t size);
 int		is_builtin(char *cmd);

--- a/srcs/execute/child.c
+++ b/srcs/execute/child.c
@@ -2,16 +2,19 @@
 
 static void execve_process(t_argv *argv, t_env *env)
 {
-	char *str[2];
+	char	**envp;
+	char	*path;
 
-	str[0] = get_path(argv, env);
-	str[1] = NULL;
-	if (!str[0])
+	path = get_path(argv, env);
+	envp = make_2_arr_env(env); /* 우채가 만들어줄 예정 */
+	if (!envp)
+		exit (FAIL);
+	if (!path)
 	{
 		perror("filename: command not found"); /* 에러 코드 모아서 수정 필요 */
 		exit(FAIL);
 	}
-	if (execve(str[0], str, NULL) == -1)
+	if (execve(path, argv->cmd, envp) == -1)
 	{
 		perror("execve ERROR");
 		exit(FAIL);

--- a/srcs/execute/child.c
+++ b/srcs/execute/child.c
@@ -25,9 +25,7 @@ void	child_process(t_argv *argv, t_env *env, int **pipes, int i)
 	set_stdout_pipe(argv, pipes, i);
 	set_stdin_redir(argv);
 	set_stdout_redir(argv);
-	if (!argv->cmd)
-		exit(SUCCESS);
-	if (is_builtin(argv->cmd[0]) == TRUE)
+	if (is_builtin(argv->cmd) == TRUE)
 	{
 		builtin_process(argv->cmd, env);
 	}

--- a/srcs/execute/execute.c
+++ b/srcs/execute/execute.c
@@ -30,7 +30,7 @@ void	wait_childs(int cnt_pipe)
 	g_error.last_errno = status;
 }
 
-void	end_execute(int cnt_pipe, pid_t **pids, int **pipes, t_argv *argv)
+void	end_execute(int cnt_pipe, pid_t *pids, int **pipes, t_argv *argv)
 {
 	wait_childs(cnt_pipe); // -> exit status 변경해줘야함 "$?"
 	close_pipe(pipes);
@@ -50,7 +50,7 @@ void	execute(t_argv *argv, t_env *env)
 		return (free_argv(argv));	// FAIL일 경우 할당 해제 필요
 	init_execute(&cnt_pipe, &pids, &pipes, argv);
 	i = -1;
-	if (cnt_pipe == 0 && is_builtin(argv->cmd[0]) == TURE)
+	if (cnt_pipe == 0 && is_builtin(argv->cmd) == TRUE)
 		single_builtin(argv, env);
 	else
 	{

--- a/srcs/execute/path.c
+++ b/srcs/execute/path.c
@@ -1,0 +1,64 @@
+#include "../../includes/minishell.h"
+
+/* 이거는 나중에 환경변수 다룰 때 재사용 해도 좋을 것 같아요 */
+static char	*get_value(t_env **env, char *key)
+{
+	t_env *tmp;
+
+	tmp = env;
+	while (tmp->next != NULL)
+	{
+		if (!ft_strcmp(tmp->key, key))
+			return (tmp->value);
+		tmp = tmp->next;
+	}
+	return (NULL);
+}
+
+static char	*join_path_cmd(char *path, char *cmd)
+{
+	char	*tmp;
+	
+	tmp = ft_strjoin("/", cmd);
+	if (!tmp)
+		return (NULL);
+	path = ft_strjoin(path, tmp);
+	if (!path)
+	{
+		free(tmp);
+		return (NULL);
+	}
+	return (path);
+}
+
+static char	*make_path(t_argv *argv, char *paths)
+{
+	char		*path;
+	struct stat	info;
+	int			i;
+
+	i = -1;
+	while (paths[++i] != NULL)
+	{
+		path = join_path_cmd(paths[i], argv->cmd[0]);
+		if (!path)
+			exit (FAIL);
+		if (stat(path, &info) == SUCCESS)
+			return (path);
+	}
+	return (NULL);
+}
+
+char	*get_path(t_argv *argv, t_env *env)
+{
+	char	*env_path;
+	char	**paths;
+
+	env_path = get_value(env, "PATH");
+	if (!env_path)
+		exit (FAIL);
+	paths = ft_split(env_path, ':');
+	if (!paths)
+		exit (FAIL);
+	return (make_path(argv, paths));
+}

--- a/srcs/execute/util_execute.c
+++ b/srcs/execute/util_execute.c
@@ -21,19 +21,21 @@ int	ft_open(char *file, int type)
 	return (fd);
 }
 
-int	is_builtin(char *cmd)
+int	is_builtin(char **cmd)
 {
 	int			i;
 	const char	*builtins[7] = {"echo", "cd", "pwd", "export",
 		"unset", "env", "exit"};
 
+	if (!cmd)
+		return (FALSE);
 	i = -1;
 	while (++i < 7)
 	{
 		if (ft_strcmp(cmd, builtins[i]) == 0)
-			return (SUCCESS);
+			return (TRUE);
 	}
-	return (FAIL);
+	return (FALSE);
 }
 
 void	*ft_malloc(size_t size)


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - 명령어 경로 찾는 함수 구현
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
명령어 경로 찾는 함수 구현 방식
1. 환경변수에서 `PATH` 경로 가져오기
2. paths `:` 을 기준으로 PATH split
3. split 문자열 수만큼 반복문 실행 : `paths[i] + “/” + cmd 명령어` full path 만들기
4. `stat`으로 full path가 제대로 된 실행파일인지 확인, 아니라면 3 반복

 ⇒ 있으면 execute()실행, 아니라면 오류메시지 출력 "filename: command not found"
