### PR TITLE
[Fix]heredoc무한루프 이슈해결#50

### DIFF
--- a/srcs/parse/create_argvs_2.c
+++ b/srcs/parse/create_argvs_2.c
@@ -56,7 +56,12 @@ static int	add_redir(t_argv **argvs, char *value, t_type *type)
 	else
 		ft_rediradd_back(&(*argvs)->in, new);
 	if (type->redir == HDOC)
+	{
+		new = create_redir(type->redir, 0);
+		if (!new)
+			return (FAIL);
 		ft_rediradd_back(&(*argvs)->hdoc, new);
+	}
 	free(value);
 	type->last = REDIR;
 	return (SUCCESS);


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - heredoc 무한루프 해결
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
- HereDoc 처리 시 이슈
    ```bash
    # 무한루프
    minishell > echo 12345 << h1 << h2 (h2 처리시 무한루프 발생) 
    ```
    
- 무한루프 발생 부분
   <img width="481" alt="스크린샷 2022-10-01 오후 2 05 41" src="https://user-images.githubusercontent.com/90084199/193394703-bae3c927-45a3-46e1-8182-fecb1f9c370c.png">
    ```c
    "<< h1 "을 처리할 때,
    - ft_rediradd_back(&(*argvs)→in, new(h1)) 실행 후,
        - argvs→ in   → h1 → NULL;
        - argvs→ hdoc → NULL;
    - ft_rediradd_back(&(*argvs)→hdoc, new(h1)) 실행 후,
        - argvs→ in   → h1 → NULL;
        - argvs→ hdoc → h1 → NULL;
    
    그 다음 "<< h2"를 처리할 때 이슈 발생. 
    - ft_rediradd_back(&(*argvs)→in, new(h2)) 실행 후,
        - argvs→ in   → h1 → h2 → NULL;
        - argvs→ hdoc → h1 → h2 → NULL; 
        *!! argvs→ in에 h2로 저장한 후 argvs→ hdoc에도 영향을 주게 됨
    - ft_rediradd_back(&(*argvs)→hdoc, new(h2)) 실행 후,
        - argvs→ in   → h1 → h2 → h2 -> h2 …;
        - argvs→ hdoc → h1 → h2 → h2 -> h2 …; 
        *!! h2 → next 값을 h2로 저장한 후, ft_redirlast에서 무한루프를 돌게 됨
    ```
 ## ✅ 변경로직 <!-- 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->