### PR TITLE
[Fix] echo 함수 printf -> ft_putstr_fd로 변경

### DIFF
--- a/srcs/execute/builtin_echo.c
+++ b/srcs/execute/builtin_echo.c
@@ -45,11 +45,11 @@ void	ft_echo(char **cmd)
 	i = -1;
 	while (cmd[++i])
 	{
-		printf("%s", cmd[i]);
+		ft_putstr_fd(cmd[i], STDOUT_FILENO);
 		if (cmd[i + 1])
-			printf(" ");
+			ft_putchar_fd(' ', STDOUT_FILENO);
 	}
 	if (flag == FALSE)
-		printf("\n");
+		ft_putchar_fd('\n', STDOUT_FILENO);
 	g_info.last_exit_num = SUCCESS;
 }


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - echo 함수 printf -> ft_putstr_fd로 변경
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - echo 함수 printf -> ft_putstr_fd로 변경
  - printf는 버퍼에 담아놨다가 개행이나 eof 만났을시 출력. redirect fd로 연결해놨다가 버퍼에서 나오기 전에 fd 리셋을 시켜버리기 때문...!
