### PR TITLE
[Fix] redirect out 먼저 처리하도록 로직 수정 close #81

### DIFF
--- a/srcs/execute/run_fork.c
+++ b/srcs/execute/run_fork.c
@@ -35,8 +35,8 @@ static void	run_child_proc(t_argv *argv, int **pipes, int i)
 	set_child_signal();
 	set_stdin_pipe(pipes, i - 1);
 	set_stdout_pipe(argv, pipes, i);
-	set_stdin_redir(argv);
 	set_stdout_redir(argv);
+	set_stdin_redir(argv);
 	if (is_builtin(argv->cmd) == TRUE)
 		run_builtin_proc(argv->cmd);
 	else


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - redirect out 먼저 처리하도록 로직 수정 
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
<img width="1002" alt="image" src="https://user-images.githubusercontent.com/90181905/193495982-c53b3598-4d18-4c02-8773-9b423f509e05.png">

- bash에서는 리다이렉트 순서에 따라서 한개한개 검사해가지고 처리하다가 에러 나면 거기서 멈추는데, 우리 로직은 infile 먼저 처리 -> outfile 먼저 처리라서 in에서 오류가 나면 무조건 exit된다.
- 그런데 리다이렉트 결과가 같은 위 두 경우에 bash는 처리가 다르게 된다.
- 우리는 일관적으로 out먼저 처리하기로 했다. (생성 무조건 먼저 되도록) 
