### PR TITLE
[Fix] 자식프로세스에서 시그널 exit code 안됨 수정 #78

### DIFF
--- a/includes/global.h
+++ b/includes/global.h
@@ -2,6 +2,7 @@
 # define GLOBAL_H
 
 # include "../libs/libft/libft.h"
+# include <stdio.h>
 
 typedef enum e_return_type
 {

--- a/includes/utils.h
+++ b/includes/utils.h
@@ -2,7 +2,6 @@
 # define UTILS_H
 
 # include "./global.h"
-# include <stdio.h>
 
 # define ERR_CMD_NOT_FOUND 127
 # define ERR_EXIT_NAN 255

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -12,16 +12,6 @@ static void	unset_echoctl(void)
 	tcsetattr(STDIN_FILENO, TCSANOW, &term);
 }
 
-static void	set_echoctl(void)
-{
-	struct termios	term;
-
-	tcgetattr(STDIN_FILENO, &term);
-	term.c_lflag |= (ECHOCTL);
-	tcsetattr(STDIN_FILENO, TCSANOW, &term);
-}
-
-
 int	main(int ac, char *av[], char *envp[])
 {
 	t_argv		*argvs;
@@ -35,7 +25,6 @@ int	main(int ac, char *av[], char *envp[])
 	g_info.pid = getpid();
 	//init_env_list(&env, envp); // 환경변수 초기화
 	init_env(envp);
-	// set_main_signal();
 	while (1)
 	{
 		argvs = NULL;
@@ -43,7 +32,6 @@ int	main(int ac, char *av[], char *envp[])
 		init_signal();
 		parse(&argvs);
 		// system("leaks minishell");
-		set_echoctl();
 		execute(argvs);
 	}
 }

--- a/srcs/utils/signal.c
+++ b/srcs/utils/signal.c
@@ -8,47 +8,25 @@ void	heredoc_sigint_handler(int signo)
 	exit(FAIL);
 }
 
-static void	sigint_handler(int signo)
+static void	signal_handler(int signo)
 {
-	pid_t   pid;
-
-    pid = waitpid(-1, NULL, WNOHANG);
-    if (pid == -1)
-    {
+	if (signo == SIGINT)
+	{
 		rl_replace_line("", 0);
-        printf("\n"); // 히어독일 경우 개행, 히어독
+        printf("\n");
         rl_on_new_line();
         rl_redisplay();
         g_info.last_exit_num = FAIL;
-    }
-    else
-	{
-		g_info.last_exit_num = signo + 128;
-        printf("\n");
 	}
-}
-
-static void	sigquit_handler(int signo)
-{
-	pid_t	pid;
-
-	pid = waitpid(-1, NULL, WNOHANG);
-	if (pid == -1)
+	else if (signo == SIGQUIT)
 	{
 		rl_on_new_line();
 		rl_redisplay();
 	}
-	else
-	{
-		g_info.last_exit_num = signo + 128;
-		ft_putstr_fd("Quit: ", 1);
-		ft_putnbr_fd(signo, 1);
-		ft_putendl_fd("", 1);
-	}
-} 
+}
 
 void	init_signal(void)
 {
-	signal(SIGINT, sigint_handler);
-	signal(SIGQUIT, sigquit_handler);
+	signal(SIGINT, signal_handler);
+	signal(SIGQUIT, signal_handler);
 }


### PR DESCRIPTION
<!--
  PR 작성 가이드
  1. 겸손한 어조를 사용하여 상대방이 기분나쁘지 않도록 노력할 것.
  2. 명확하게 질문하고 명확하게 답변할 것.
  3. 새로운 모듈 설치시 PR message에 기재할 것.
  4. PR 올리기전에 branch 반드시 확인할 것.
 -->
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - ⚡️자식프로세스에서 시그널 exit code 안됨 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - 자식 프로세스에서 부모의 전역변수 할당이 안되기 때문에 로직 수정
  - 자식 프로세스에서는 디폴트로 처리하고, 부모 프로세스에서 시그널 출력하고 && last_exit_num바꿔주기
 
