### PR TITLE
[Fix] 환경변수 없어졌을 때 에러 안나도록 수정

### DIFF
--- a/srcs/execute/builtin_unset.c
+++ b/srcs/execute/builtin_unset.c
@@ -1,5 +1,18 @@
 #include "../../includes/execute.h"
 
+static void	del_env_one(t_env *del)
+{
+	if (del->prev)
+		del->prev->next = del->next;
+	else
+		g_info.env_list = del->next;
+	if (del->next)
+		del->next->prev = del->prev;
+	free(del->key);
+	free(del->value);
+	free(del);
+}
+
 void	ft_unset(char **cmd)
 {
 	t_env	*del;
@@ -12,14 +25,7 @@ void	ft_unset(char **cmd)
 	{
 		del = get_env(cmd[i]);
 		if (del)
-		{
-			del->prev->next = del->next;
-			if (del->next)
-				del->next->prev = del->prev;
-			free(del->key);
-			free(del->value);
-			free(del);
-		}
+			del_env_one(del);
 		else
 		{
 			if (!is_valid_key(cmd[i]))

--- a/srcs/utils/env2.c
+++ b/srcs/utils/env2.c
@@ -78,6 +78,7 @@ void	add_env(t_env **lst, char *env)
 		tmp->next = *lst;
 		tmp->prev = NULL;
 		*lst = tmp;
+		g_info.env_list = *lst;
 		return ;
 	}
 	while (tmp->next && ft_strcmp(tmp->key, env) < 0)
@@ -97,7 +98,6 @@ void	init_env(char **env)
 	head = NULL;
 	while (env[++i])
 		add_env(&head, env[i]);
-	g_info.env_list = head;
 	lvl = get_env("SHLVL");
 	if (lvl)
 	{


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  -환경변수 없어졌을 때 에러 안나도록 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - env2.c add_env함수에서 lst가 없을 경우 새로 만든녀석을 전역변수에 삽입하도록 수정
  - unset에서 처음꺼 unset 할때 head 주소값 옮겨주도록 수정
