### PR TITLE
[Fix] Ctrl + D 종료 시 exit 상태코드 수정

### DIFF
--- a/srcs/parse/parse.c
+++ b/srcs/parse/parse.c
@@ -39,7 +39,7 @@ static int	check_input(char *input)
 	if (!seek)
 	{
 		ft_putstr_fd("exit\n", STDOUT_FILENO);
-		exit(SUCCESS);
+		exit(g_info.last_exit_num);
 	}
 	if (!(*seek))
 		return (FAIL);


### PR DESCRIPTION
 ## 📌 개요 <!-- PR내용에 대해 축약해서 적어주세요. -->
  - Ctrl + D 종료 시 exit 상태코드 수정
 ## 💻 작업사항 <!-- PR내용에 대해 상세설명이 필요하다면 이 부분에 기재 해주세요. -->
  - Ctrl + D 종료 시 exit 상태코드 수정 (기존 SUCCESS -> g_info.last_exit_num)
 